### PR TITLE
report: December 2024

### DIFF
--- a/2024/12.md
+++ b/2024/12.md
@@ -46,13 +46,13 @@ Overall, the community health is strong. The ASF Project Statistics gives the pr
 
 We continue to see contributions from a small group of dedicated individuals. Things remain stable and the project continues to see good traffic.
 
-Several patch and major updates across our platforms, plugins, and tooling has been released.
+Several patches and major updates across our platforms, plugins, and tooling have been released.
 
 Some contributors focused on updating our file and camera plugins. The file plugin received a few patch releases to improve the handling of specific file paths in certain configured environments and to unify behavior between iOS and Android.
 
 Additionally, we prepared a major release for the camera plugin to comply with Android's new permission requirements.
 
-For our platforms, we published a beta release of cordova-ios to modernize the codebase, add new features, and resolve localization issues through an improved project structure. The goal of this beta release was to engage with the community in testing these upcoming major and potentially breaking changes. This engagement would also include plugin developer to ensure they are able to prepare for the next release.
+For our platforms, we published a beta release of cordova-ios to modernize the codebase, add new features, and resolve localization issues through an improved project structure. The goal of this beta release was to engage with the community in testing these upcoming major and potentially breaking changes. This engagement would also include plugin developers to ensure they are able to prepare for the next release.
 
 Feedback provided by the community and plugin developers was used to address any reported issues, further development, and improvements to our documentation to explain new behaviors or the rationale behind specific changes.
 

--- a/2024/12.md
+++ b/2024/12.md
@@ -1,0 +1,64 @@
+## Status report for the Apache Cordova project - December 2024
+
+## Description
+
+A platform for building native mobile applications using HTML, CSS and JavaScript.
+
+## Project Status
+
+**Current project status:**
+
+Our current work continues on staying updated with changes to iOS and Android, our most utilized platforms, alongside ensuring regular updates to plugins.
+
+Our status dashboard at http://status.cordova.io remains mostly all green and our nightly builds are still extremely stable.
+
+**Issues for the board:**
+
+There are no issues requiring board attention at this time.
+
+## Membership Data
+
+There are currently 99 committers and 96 PMC members in this project.
+
+The Committer-to-PMC ratio is roughly 1:1.
+
+**Community changes, past quarter:**
+
+- No new PMC members. Last addition was Pieter Van Poyer on 2021-04-06.
+- No new committers. Last addition was Pieter Van Poyer on 2021-04-06.
+
+## Project Activity
+
+Our project made releases this quarter for our core platforms to keep up with current requirements.
+
+**Releases:**
+
+- cordova-plugin-file@8.1.3 was released on 2024-11-20.
+- cordova-lib@12.0.2 was released on 2024-11-02.
+- cordova-plugin-camera@8.0.0 was released on 2024-11-02.
+- cordova-plugin-file@8.1.2 was released on 2024-10-30.
+- cordova-plugin-file@8.1.1 was released on 2024-10-24.
+- cordova-ios@8.0.0-beta.1 was released on 2024-10-21.
+
+## Community Health
+
+Overall, the community health is strong. The ASF Project Statistics gives the project a Community Health Score (Chi): 4.70 (Healthy)
+
+We continue to see contributions from a small group of dedicated individuals. Things remain stable and the project continues to see good traffic.
+
+Several patch and major updates across our platforms, plugins, and tooling has been released.
+
+Some contributors focused on updating our file and camera plugins. The file plugin received a few patch releases to improve the handling of specific file paths in certain configured environments and to unify behavior between iOS and Android.
+
+Additionally, we prepared a major release for the camera plugin to comply with Android's new permission requirements.
+
+For our platforms, we published a beta release of cordova-ios to modernize the codebase, add new features, and resolve localization issues through an improved project structure. The goal of this beta release was to engage with the community in testing these upcoming major and potentially breaking changes. This engagement would also include plugin developer to ensure they are able to prepare for the next release.
+
+Feedback provided by the community and plugin developers was used to address any reported issues, further development, and improvements to our documentation to explain new behaviors or the rationale behind specific changes.
+
+Github discussions have become how our community supports each other. Our discussion area is live at https://github.com/apache/cordova/discussions and activity is forwarded to the 'issues' list.
+
+## Mailing List Activity
+
+- dev@cordova.apache.org had a 161% increase in traffic in the past quarter (81 emails compared to 31)
+- issues@cordova.apache.org had a 21% increase in traffic in the past quarter (988 emails compared to 810)


### PR DESCRIPTION
Board Report for December 2024

Note: The `Github Activity` section which use to print metrics for issues, prs, and commits were removed. The reporting tool which calculated the metrics has not been collecting data for the past three months. I had reported the issue but it appears that the data is still missing. I also heard that the board prefers the metrics to not be copied. Since metrics were not available, I tried to sum up what was done.